### PR TITLE
SFM-2923 Remove access to window

### DIFF
--- a/bin/jsencrypt.js
+++ b/bin/jsencrypt.js
@@ -2285,8 +2285,6 @@ var JSEncrypt = /** @class */ (function () {
     return JSEncrypt;
 }());
 
-window.JSEncrypt = JSEncrypt;
-
 exports.JSEncrypt = JSEncrypt;
 exports.default = JSEncrypt;
 


### PR DESCRIPTION
We don't use window.JSEncrypt anywhere. It has also been removed from the upstream repo: https://github.com/travist/jsencrypt/commit/b7d477f6deaf3c65e750127042c1b60111f627ef#diff-e6efe78de612e2963eca0279a1452cdd512f82c7d44c11dca3bea10190d4b1f6

Chrome extensions (v3 manifest, see https://developer.chrome.com/docs/extensions/mv3/intro/platform-vision/) no longer allow access to the `window` element. by trying to use this, chrome throws an error: Uncaught ReferenceError: window is not defined

As we don't use window.JSEncrypt anywhere, we can just remove it.